### PR TITLE
JID3314-78: Implement Filtering, Sorting, and Pagination to Discrepancy and Statistics Tables

### DIFF
--- a/CDC-Data-Reconciliation-Frontend/package-lock.json
+++ b/CDC-Data-Reconciliation-Frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "cdc-data-reconciliation-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-table": "^8.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
         "react-router-dom": "^6.19.0"
       },
       "devDependencies": {
@@ -1089,6 +1091,37 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.12.0.tgz",
+      "integrity": "sha512-LlEQ1Gpz4bfpiET+qmle4BhKDgKN3Y/sssc+O/wLqX8HRtjV+nhusYbllZlutZfMR8oeef83whKTj/VhaV8EeA==",
+      "dependencies": {
+        "@tanstack/table-core": "8.12.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.12.0.tgz",
+      "integrity": "sha512-cq/ylWVrOwixmwNXQjgZaQw1Izf7+nPxjczum7paAnMtwPg1S2qRAJU+Jb8rEBUWm69voC/zcChmePlk2hc6ug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.4",
@@ -3768,6 +3801,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/CDC-Data-Reconciliation-Frontend/package.json
+++ b/CDC-Data-Reconciliation-Frontend/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1",
     "react-router-dom": "^6.19.0"
   },
   "devDependencies": {

--- a/CDC-Data-Reconciliation-Frontend/src/components/DebouncedInput.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/DebouncedInput.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react"
+
+// A debounced input react component
+export default function DebouncedInput({ value: initialValue, onChange, debounce = 500, ...props }) {
+  const [value, setValue] = useState(initialValue)
+
+  useEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      onChange(value)
+    }, debounce)
+
+    return () => clearTimeout(timeout)
+  }, [value])
+
+  return <input {...props} value={value} onChange={(e) => setValue(e.target.value)} />
+}

--- a/CDC-Data-Reconciliation-Frontend/src/components/Filter.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Filter.jsx
@@ -1,0 +1,29 @@
+import { useMemo } from "react"
+import DebouncedInput from "./DebouncedInput"
+
+export default function Filter({ column }) {
+  const columnFilterValue = column.getFilterValue()
+
+  const sortedUniqueValues = useMemo(
+    () => Array.from(column.getFacetedUniqueValues().keys()).sort(),
+    [column.getFacetedUniqueValues()]
+  )
+
+  return (
+    <>
+      <datalist id={column.id + "list"}>
+        {sortedUniqueValues.slice(0, 5000).map((value) => (
+          <option value={value} key={value} />
+        ))}
+      </datalist>
+      <DebouncedInput
+        type='text'
+        value={columnFilterValue ?? ""}
+        onChange={(value) => column.setFilterValue(String(value))}
+        placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
+        className='border shadow rounded w-full px-2 font-normal'
+        list={column.id + "list"}
+      />
+    </>
+  )
+}

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -26,10 +26,14 @@ import {
 export default function Report({ reportID }) {
   const [results, setResults] = useState(null)
   const [statistics, setStatistics] = useState(null)
+  const [totalStatistics, setTotalStatistics] = useState({})
   const [showDiseaseStats, setShowDiseaseStats] = useState(false)
 
   const [discColumnFilters, setDiscColumnFilters] = useState([])
   const [discGlobalFilter, setDiscGlobalFilter] = useState("")
+
+  const [statColumnFilters, setStatColumnFilters] = useState([])
+  const [statGlobalFilter, setStatGlobalFilter] = useState("")
 
   const discColumns = useMemo(() => [
     {
@@ -72,6 +76,49 @@ export default function Report({ reportID }) {
     },
   ])
 
+  const statColumns = useMemo(() => [
+    {
+      header: "Event Code",
+      accessorKey: "EventCode",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Event Name",
+      accessorKey: "EventName",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Total Cases",
+      accessorFn: (row) => row.TotalCases.toString(),
+      id: "TotalCases",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Duplicates",
+      accessorFn: (row) => row.TotalDuplicates.toString(),
+      id: "TotalDuplicates",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Missing From CDC",
+      accessorFn: (row) => row.TotalMissingFromCDC.toString(),
+      id: "TotalMissingFromCDC",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Missing From State",
+      accessorFn: (row) => row.TotalMissingFromState.toString(),
+      id: "TotalMissingFromState",
+      footer: (props) => props.column.id,
+    },
+    {
+      header: "Wrong Attributes",
+      accessorFn: (row) => row.TotalWrongAttributes.toString(),
+      id: "TotalWrongAttributes",
+      footer: (props) => props.column.id,
+    },
+  ])
+
   const discTable = useReactTable({
     data: results,
     columns: discColumns,
@@ -86,6 +133,28 @@ export default function Report({ reportID }) {
     },
     onColumnFiltersChange: setDiscColumnFilters,
     onGlobalFilterChange: setDiscGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
+
+  const statTable = useReactTable({
+    data: statistics,
+    columns: statColumns,
+    state: {
+      columnFilters: statColumnFilters,
+      globalFilter: statGlobalFilter,
+    },
+    initialState: {
+      pagination: {
+        pageSize: 5,
+      },
+    },
+    onColumnFiltersChange: setStatColumnFilters,
+    onGlobalFilterChange: setStatGlobalFilter,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -117,15 +186,13 @@ export default function Report({ reportID }) {
           totalWrongAttributes += stat.TotalWrongAttributes || 0
         })
 
-        setStatistics({
-          totals: {
-            TotalCases: totalCases,
-            TotalDuplicates: totalDuplicates,
-            TotalMissingFromCDC: totalMissingFromCDC,
-            TotalMissingFromState: totalMissingFromState,
-            TotalWrongAttributes: totalWrongAttributes,
-          },
-          eventCodeStats: statsData,
+        setStatistics(statsData)
+        setTotalStatistics({
+          TotalCases: totalCases,
+          TotalDuplicates: totalDuplicates,
+          TotalMissingFromCDC: totalMissingFromCDC,
+          TotalMissingFromState: totalMissingFromState,
+          TotalWrongAttributes: totalWrongAttributes,
         })
       } catch (error) {
         console.error("Unable to fetch statistics", error)
@@ -177,6 +244,10 @@ export default function Report({ reportID }) {
     document.body.removeChild(linking)
   }
 
+  const handleStatsDownload = (e) => {
+    // Waffy's Task
+  }
+
   return (
     <div className='mt-5 py-5 w-5/6 flex flex-col items-center gap-6'>
       {results && (
@@ -197,57 +268,169 @@ export default function Report({ reportID }) {
               </button>
 
               {/* Overall Report Statistics */}
-              {!showDiseaseStats && (
-                <table className='w-full text-center mb-4'>
-                  <thead>
-                    <tr className='border-b-2 border-slate-900'>
-                      <th>Total Cases</th>
-                      <th>Total Duplicates</th>
-                      <th>Total Missing From CDC</th>
-                      <th>Total Missing From States</th>
-                      <th>Total Wrong Attributes</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td>{statistics.totals.TotalCases}</td>
-                      <td>{statistics.totals.TotalDuplicates}</td>
-                      <td>{statistics.totals.TotalMissingFromCDC}</td>
-                      <td>{statistics.totals.TotalMissingFromState}</td>
-                      <td>{statistics.totals.TotalWrongAttributes}</td>
-                    </tr>
-                  </tbody>
-                </table>
-              )}
+
+              <table className='w-full text-center mb-4'>
+                <thead>
+                  <tr className='border-b-2 border-slate-900'>
+                    <th>Total Cases</th>
+                    <th>Total Duplicates</th>
+                    <th>Total Missing From CDC</th>
+                    <th>Total Missing From States</th>
+                    <th>Total Wrong Attributes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{totalStatistics.TotalCases}</td>
+                    <td>{totalStatistics.TotalDuplicates}</td>
+                    <td>{totalStatistics.TotalMissingFromCDC}</td>
+                    <td>{totalStatistics.TotalMissingFromState}</td>
+                    <td>{totalStatistics.TotalWrongAttributes}</td>
+                  </tr>
+                </tbody>
+              </table>
 
               {/* Disease Specific Statistics */}
               {showDiseaseStats && (
-                <table className='w-full text-center'>
-                  <thead>
-                    <tr className='border-b-2 border-slate-900'>
-                      <th>Event Code</th>
-                      <th>Event Name</th>
-                      <th>Total Cases</th>
-                      <th>Total Duplicates</th>
-                      <th>Total Missing From CDC</th>
-                      <th>Total Missing From States</th>
-                      <th>Total Wrong Attributes</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {statistics.eventCodeStats.map((stats) => (
-                      <tr key={stats.EventCode}>
-                        <td>{stats.EventCode}</td>
-                        <td>{stats.EventName}</td>
-                        <td>{stats.TotalCases}</td>
-                        <td>{stats.TotalDuplicates}</td>
-                        <td>{stats.TotalMissingFromCDC}</td>
-                        <td>{stats.TotalMissingFromState}</td>
-                        <td>{stats.TotalWrongAttributes}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <div>
+                  <div className='w-full flex flex-row items-center justify-between'>
+                    <DebouncedInput
+                      value={statGlobalFilter ?? ""}
+                      onChange={(value) => setStatGlobalFilter(String(value))}
+                      className='p-2 font-lg shadow border border-block'
+                      placeholder='Search all columns...'
+                    />
+                    <button
+                      type='button'
+                      className='bg-blue-400 text-white px-5 py-2 rounded-md hover:bg-blue-600 flex flex-row items-center justify-around gap-2'
+                      onClick={handleStatsDownload}
+                    >
+                      Download CSV
+                      <MdFileDownload size={23} />
+                    </button>
+                  </div>
+                  <div className='border border-slate-400 rounded-xl my-3'>
+                    <table className='table-auto'>
+                      <thead>
+                        {statTable.getHeaderGroups().map((headerGroup) => (
+                          <tr key={headerGroup.id} className='border-b border-slate-400'>
+                            {headerGroup.headers.map((header) => {
+                              return (
+                                <th className='p-2' key={header.id} colSpan={header.colSpan}>
+                                  {header.isPlaceholder ? null : (
+                                    <>
+                                      <div
+                                        {...{
+                                          className: header.column.getCanSort()
+                                            ? "cursor-pointer select-none flex flex-row items-center justify-start gap-2"
+                                            : "flex flex-row items-center justify-start gap-2",
+                                          onClick: header.column.getToggleSortingHandler(),
+                                        }}
+                                      >
+                                        {flexRender(header.column.columnDef.header, header.getContext())}
+                                        {{
+                                          asc: <FaSortUp />,
+                                          desc: <FaSortDown />,
+                                        }[header.column.getIsSorted()] ?? null}
+                                      </div>
+                                      {header.column.getCanFilter() ? (
+                                        <div>
+                                          <Filter column={header.column} table={statTable} />
+                                        </div>
+                                      ) : null}
+                                    </>
+                                  )}
+                                </th>
+                              )
+                            })}
+                          </tr>
+                        ))}
+                      </thead>
+                      <tbody>
+                        {statTable.getRowModel().rows.map((row, index) => {
+                          return (
+                            <tr
+                              {...{
+                                className:
+                                  index < statTable.getRowModel().rows.length - 1 ? "border-b border-slate-400" : "",
+                              }}
+                              key={row.id}
+                            >
+                              {row.getVisibleCells().map((cell) => {
+                                return (
+                                  <td className='p-1' key={cell.id}>
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                  </td>
+                                )
+                              })}
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className='flex items-center gap-2 justify-center'>
+                    <button
+                      className='border rounded p-1 border-slate-400'
+                      onClick={() => statTable.setPageIndex(0)}
+                      disabled={!statTable.getCanPreviousPage()}
+                    >
+                      <MdKeyboardDoubleArrowLeft className='text-xl' />
+                    </button>
+                    <button
+                      className='border rounded p-1 border-slate-400'
+                      onClick={() => statTable.previousPage()}
+                      disabled={!statTable.getCanPreviousPage()}
+                    >
+                      <MdKeyboardArrowLeft className='text-xl' />
+                    </button>
+                    <button
+                      className='border rounded p-1 border-slate-400'
+                      onClick={() => statTable.nextPage()}
+                      disabled={!statTable.getCanNextPage()}
+                    >
+                      <MdKeyboardArrowRight className='text-xl' />
+                    </button>
+                    <button
+                      className='border rounded p-1 border-slate-400'
+                      onClick={() => statTable.setPageIndex(statTable.getPageCount() - 1)}
+                      disabled={!statTable.getCanNextPage()}
+                    >
+                      <MdKeyboardDoubleArrowRight className='text-xl' />
+                    </button>
+                    <span className='flex items-center gap-1'>
+                      <div>Page</div>
+                      <strong>
+                        {statTable.getState().pagination.pageIndex + 1} of {statTable.getPageCount()}
+                      </strong>
+                    </span>
+                    <span className='flex items-center gap-1'>
+                      | Go to page:
+                      <input
+                        type='number'
+                        defaultValue={statTable.getState().pagination.pageIndex + 1}
+                        onChange={(e) => {
+                          const page = e.target.value ? Number(e.target.value) - 1 : 0
+                          statTable.setPageIndex(page)
+                        }}
+                        className='border p-1 rounded w-16 border-slate-400'
+                      />
+                    </span>
+                    <select
+                      className='border p-1 rounded border-slate-400'
+                      value={statTable.getState().pagination.pageSize}
+                      onChange={(e) => {
+                        statTable.setPageSize(Number(e.target.value))
+                      }}
+                    >
+                      {[5, 10, 20, 30, 40, 50, 100].map((pageSize) => (
+                        <option key={pageSize} value={pageSize}>
+                          Show {pageSize}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
               )}
             </>
           )}


### PR DESCRIPTION
I added @tanstack/react-table and react-icons as packages in order to facilitate the filtering, sorting, pagination and to have icons on the page. Make sure to do "npm i" before "npm run dev" as these are newly added packages.

@waffy1901 I added the function handleStatsDownload that you should use to complete your task that allows a user to download the csv for the statistics. I also did not make the tables a separate component as it would have been harder to implement your [JID3314-113](https://jid3314.atlassian.net/browse/JID3314-113) task.

Here is what the table looks like:
![image](https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/43588191/a5689317-01c1-4f3f-a6c2-2b9498a76db4)
