### PR TITLE
JID3314-113 Display filtered results via the click of a number in the 4 right-most columns of the statistics table

### DIFF
--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -76,6 +76,10 @@ export default function Report({ reportID }) {
     },
   ])
 
+  const handleStatsFilter = (columnName, value) => {
+    setDiscColumnFilters([{ id: columnName, value: value.toString() }])
+  }
+
   const statColumns = useMemo(() => [
     {
       header: "Event Code",
@@ -95,25 +99,57 @@ export default function Report({ reportID }) {
     },
     {
       header: "Duplicates",
-      accessorFn: (row) => row.TotalDuplicates.toString(),
+      accessorFn: (row) => row.TotalDuplicates,
+      cell: (info) => (
+        <span
+          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          onClick={() => handleStatsFilter("TotalDuplicates", info.getValue())}
+        >
+          {info.getValue().toString()}
+        </span>
+      ),
       id: "TotalDuplicates",
       footer: (props) => props.column.id,
     },
     {
       header: "Missing From CDC",
-      accessorFn: (row) => row.TotalMissingFromCDC.toString(),
+      accessorFn: (row) => row.TotalMissingFromCDC,
+      cell: (info) => (
+        <span
+          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          onClick={() => handleStatsFilter("TotalMissingFromCDC", info.getValue())}
+        >
+          {info.getValue().toString()}
+        </span>
+      ),
       id: "TotalMissingFromCDC",
       footer: (props) => props.column.id,
     },
     {
       header: "Missing From State",
-      accessorFn: (row) => row.TotalMissingFromState.toString(),
+      accessorFn: (row) => row.TotalMissingFromState,
+      cell: (info) => (
+        <span
+          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          onClick={() => handleStatsFilter("TotalMissingFromState", info.getValue())}
+        >
+          {info.getValue().toString()}
+        </span>
+      ),
       id: "TotalMissingFromState",
       footer: (props) => props.column.id,
     },
     {
       header: "Wrong Attributes",
-      accessorFn: (row) => row.TotalWrongAttributes.toString(),
+      accessorFn: (row) => row.TotalWrongAttributes,
+      cell: (info) => (
+        <span
+          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          onClick={() => handleStatsFilter("TotalWrongAttributes", info.getValue())}
+        >
+          {info.getValue().toString()}
+        </span>
+      ),
       id: "TotalWrongAttributes",
       footer: (props) => props.column.id,
     },

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -95,12 +95,12 @@ export default function Report({ reportID }) {
     },
     {
       header: "Duplicates",
-      accessorFn: (row) => row.TotalDuplicates,
+      accessorFn: (row) => row.TotalDuplicates.toString(),
       cell: (info) => (
         <span
-          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          className='text-blue-500 cursor-pointer underline'
         >
-          {info.getValue().toString()}
+          {info.getValue()}
         </span>
       ),
       id: "TotalDuplicates",
@@ -108,12 +108,12 @@ export default function Report({ reportID }) {
     },
     {
       header: "Missing From CDC",
-      accessorFn: (row) => row.TotalMissingFromCDC,
+      accessorFn: (row) => row.TotalMissingFromCDC.toString(),
       cell: (info) => (
         <span
-          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          className='text-blue-500 cursor-pointer underline'
         >
-          {info.getValue().toString()}
+          {info.getValue()}
         </span>
       ),
       id: "TotalMissingFromCDC",
@@ -121,12 +121,12 @@ export default function Report({ reportID }) {
     },
     {
       header: "Missing From State",
-      accessorFn: (row) => row.TotalMissingFromState,
+      accessorFn: (row) => row.TotalMissingFromState.toString(),
       cell: (info) => (
         <span
-          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          className='text-blue-500 cursor-pointer underline'
         >
-          {info.getValue().toString()}
+          {info.getValue()}
         </span>
       ),
       id: "TotalMissingFromState",
@@ -134,12 +134,12 @@ export default function Report({ reportID }) {
     },
     {
       header: "Wrong Attributes",
-      accessorFn: (row) => row.TotalWrongAttributes,
+      accessorFn: (row) => row.TotalWrongAttributes.toString(),
       cell: (info) => (
         <span
-          style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
+          className='text-blue-500 cursor-pointer underline'
         >
-          {info.getValue().toString()}
+          {info.getValue()}
         </span>
       ),
       id: "TotalWrongAttributes",
@@ -295,8 +295,6 @@ export default function Report({ reportID }) {
   }
 
   const handleStatClick = (col, row) => {
-    console.log(col.id, row)
-
     setDiscColumnFilters(null)
     switch (col.id) {
       case "TotalDuplicates":
@@ -364,8 +362,8 @@ export default function Report({ reportID }) {
   }
 
   const clearStatFilters = () => {
-    setDiscColumnFilters([])
-    setDiscGlobalFilter("")
+    setStatColumnFilters([])
+    setStatGlobalFilter("")
   }
 
   return (

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -76,10 +76,6 @@ export default function Report({ reportID }) {
     },
   ])
 
-  const handleStatsFilter = (columnName, value) => {
-    setDiscColumnFilters([{ id: columnName, value: value.toString() }])
-  }
-
   const statColumns = useMemo(() => [
     {
       header: "Event Code",
@@ -103,7 +99,6 @@ export default function Report({ reportID }) {
       cell: (info) => (
         <span
           style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
-          onClick={() => handleStatsFilter("TotalDuplicates", info.getValue())}
         >
           {info.getValue().toString()}
         </span>
@@ -117,7 +112,6 @@ export default function Report({ reportID }) {
       cell: (info) => (
         <span
           style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
-          onClick={() => handleStatsFilter("TotalMissingFromCDC", info.getValue())}
         >
           {info.getValue().toString()}
         </span>
@@ -131,7 +125,6 @@ export default function Report({ reportID }) {
       cell: (info) => (
         <span
           style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
-          onClick={() => handleStatsFilter("TotalMissingFromState", info.getValue())}
         >
           {info.getValue().toString()}
         </span>
@@ -145,7 +138,6 @@ export default function Report({ reportID }) {
       cell: (info) => (
         <span
           style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}
-          onClick={() => handleStatsFilter("TotalWrongAttributes", info.getValue())}
         >
           {info.getValue().toString()}
         </span>
@@ -283,10 +275,12 @@ export default function Report({ reportID }) {
   const handleStatsDownload = (e) => {
     const csvStatsData = 
       "EventCode,EventName,TotalCases,TotalDuplicates,TotalMissingFromCDC,TotalMissingFromState,TotalWrongAttributes\n" +
-      statistics.map(
-        (stat) => 
-          `${stat.EventCode},"${stat.EventName}",${stat.TotalCases},${stat.TotalDuplicates},${stat.TotalMissingFromCDC},${stat.TotalMissingFromState},${stat.TotalWrongAttributes}`
-      ).join("\n")
+      statistics
+        .map(
+          (stat) => 
+            `${stat.EventCode},"${stat.EventName}",${stat.TotalCases},${stat.TotalDuplicates},${stat.TotalMissingFromCDC},${stat.TotalMissingFromState},${stat.TotalWrongAttributes}`
+      )
+      .join("\n")
 
     const blob = new Blob([csvStatsData], { type: "text/csv;charset=utf-8," })
     const linkURL = URL.createObjectURL(blob)
@@ -298,6 +292,80 @@ export default function Report({ reportID }) {
     document.body.appendChild(linking)
     linking.click()
     document.body.removeChild(linking)
+  }
+
+  const handleStatClick = (col, row) => {
+    console.log(col.id, row)
+
+    setDiscColumnFilters(null)
+    switch (col.id) {
+      case "TotalDuplicates":
+        if (row.TotalDuplicates === 0) return
+
+        setDiscColumnFilters([
+          {
+            id: "ReasonID",
+            value: "1",
+          },
+          {
+            id: "EventCode",
+            value: row.EventCode,
+          },
+        ])
+      case "TotalMissingFromCDC":
+        if (row.TotalMissingFromCDC === 0) return
+
+        setDiscColumnFilters([
+          {
+            id: "ReasonID",
+            value: "2",
+          },
+          {
+            id: "EventCode",
+            value: row.EventCode,
+          },
+        ])
+        break
+
+      case "TotalWrongAttributes":
+        if (row.TotalWrongAttributes === 0) return
+
+        setDiscColumnFilters([
+          {
+            id: "ReasonID",
+            value: "3",
+          },
+          {
+            id: "EventCode",
+            value: row.EventCode,
+          },
+        ])
+        break
+      case "TotalMissingFromState":
+        if (row.TotalMissingFromState === 0) return
+
+        setDiscColumnFilters([
+          {
+            id: "ReasonID",
+            value: "4",
+          },
+          {
+            id: "EventCode",
+            value: row.EventCode,
+          },
+        ])
+        break
+    }
+  }
+
+  const clearDiscFilters = () => {
+    setDiscColumnFilters([])
+    setDiscGlobalFilter("")
+  }
+
+  const clearStatFilters = () => {
+    setDiscColumnFilters([])
+    setDiscGlobalFilter("")
   }
 
   return (
@@ -352,6 +420,14 @@ export default function Report({ reportID }) {
                       className='p-2 font-lg shadow border border-block'
                       placeholder='Search all columns...'
                     />
+                    <button
+                      type="button"
+                      className="bg-blue-500 text-white px-3 py-1 rounded-md hover:bg-blue-700"
+                      onClick={clearStatFilters}
+                    >
+                      Clear Filters
+                    </button>
+
                     <button
                       type='button'
                       className='bg-blue-400 text-white px-5 py-2 rounded-md hover:bg-blue-600 flex flex-row items-center justify-around gap-2'
@@ -410,7 +486,11 @@ export default function Report({ reportID }) {
                             >
                               {row.getVisibleCells().map((cell) => {
                                 return (
-                                  <td className='p-1' key={cell.id}>
+                                  <td
+                                    onClick={() => handleStatClick(cell.column, cell.row.original)}
+                                    className='p-1'
+                                    key={cell.id}
+                                  >
                                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                   </td>
                                 )
@@ -495,6 +575,14 @@ export default function Report({ reportID }) {
                 className='p-2 font-lg shadow border border-block'
                 placeholder='Search all columns...'
               />
+              <button
+                type="button"
+                className="bg-blue-500 text-white px-3 py-1 rounded-md hover:bg-blue-700"
+                onClick={clearDiscFilters}
+              >
+                Clear Filters
+              </button>
+
               <button
                 type='button'
                 className='bg-blue-400 text-white px-5 py-2 rounded-md hover:bg-blue-600 flex flex-row items-center justify-around gap-2'


### PR DESCRIPTION
Added the functionality of clicking on a stat in the Duplicates, Missing From CDC, Missing From States, and Wrong Attributes columns and then filtering the discrepancy table based on the stat clicked. In addition, I added a clear filters button to both tables, where if you click it, the discrepancy table will be reset to its original state.
<img width="992" alt="Screenshot 2024-02-29 at 11 12 10 AM" src="https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/80718213/eba36375-bbf2-4b9a-8908-74d6d642ac10">
