### PR TITLE
Updating archive functionality

### DIFF
--- a/CDC-Data-Reconciliation-Backend/server.py
+++ b/CDC-Data-Reconciliation-Backend/server.py
@@ -109,9 +109,6 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
     
     # Fetching the archive_path for saving the Report
     archive_path = await get_config_setting("archive_path")
-    # Making sure the archive_path has been set, otherwise throwing an exception
-    if not archive_path:
-        raise HTTPException(status_code=500, detail="Archive path configuration is missing")
 
     cdc_content = await cdc_file.read()
     cdc_save_to = os.path.join(app.dir, folder_name, id, cdc_file.filename)
@@ -150,13 +147,14 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
             tup = (reportId,) + tuple(row.values())
             stats_list.append(tup)
 
-    # Making a folder for the specific reportId
-    archive_save_to = os.path.join(archive_path, str(reportId))
-    os.makedirs(archive_save_to, exist_ok=True)
+    if archive_path:
+        # Making a folder for the specific reportId
+        archive_save_to = os.path.join(archive_path, str(reportId))
+        os.makedirs(archive_save_to, exist_ok=True)
 
-    # writing the newly created results file to the archive folder too
-    shutil.copy2(res_file, archive_save_to)
-    shutil.copy2(stats_file, archive_save_to)
+        # writing the newly created results file to the archive folder too
+        shutil.copy2(res_file, archive_save_to)
+        shutil.copy2(stats_file, archive_save_to)
 
     # Add reportId to each row
     new_res = [(reportId,) + row for row in res]
@@ -189,8 +187,7 @@ async def automatic_report(year: int, cdc_file:  UploadFile = File(None)):
     # Fetching the archive_path for saving the Report
     archive_path = await get_config_setting("archive_path")
     # Making sure the archive_path has been set, otherwise throwing an exception
-    if not archive_path:
-        raise HTTPException(status_code=500, detail="Archive path configuration is missing")
+    
     
     
     id = str(uuid.uuid4())
@@ -236,14 +233,15 @@ async def automatic_report(year: int, cdc_file:  UploadFile = File(None)):
         for row in reader:
             tup = (reportId,) + tuple(row.values())
             stats_list.append(tup)
-            
-    # Making a folder for the specific reportId
-    archive_save_to = os.path.join(archive_path, str(reportId))
-    os.makedirs(archive_save_to, exist_ok=True)
+    
+    if archive_path:
+        # Making a folder for the specific reportId
+        archive_save_to = os.path.join(archive_path, str(reportId))
+        os.makedirs(archive_save_to, exist_ok=True)
 
-    # writing the newly created results file to the archive folder too
-    shutil.copy2(res_file, archive_save_to)
-    shutil.copy2(stats_file, archive_save_to)
+        # writing the newly created results file to the archive folder too
+        shutil.copy2(res_file, archive_save_to)
+        shutil.copy2(stats_file, archive_save_to)
 
     # Add reportId to each row
     new_res = [(reportId,) + row for row in res]


### PR DESCRIPTION
Changing archive functionality to not throw errors if not archive path has been set. If there is not one, archiving is skipped.