### PR TITLE
Pass cdc filter option to backend from frontend

### DIFF
--- a/CDC-Data-Reconciliation-Backend/server.py
+++ b/CDC-Data-Reconciliation-Backend/server.py
@@ -99,7 +99,7 @@ app.liteConn.commit()
 
 
 @app.post("/manual_report")
-async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFile = File(None), isCDCFilter: bool = Form(False)):
+async def manual_report(isCDCFilter: bool, state_file: UploadFile = File(None), cdc_file:  UploadFile = File(None)):
     folder_name = "temp"
     if not os.path.exists(os.path.join(app.dir, "temp")):
         os.makedirs(os.path.join(app.dir, "temp"))
@@ -186,7 +186,7 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
 
 
 @app.post("/automatic_report")
-async def automatic_report(year: int, cdc_file:  UploadFile = File(None), isCDCFilter: bool = Form(False)):
+async def automatic_report(year: int, isCDCFilter: bool, cdc_file:  UploadFile = File(None)):
     # Run query to retrieve data from NBS ODSE database
     (column_names, state_content) = run_query(year)
     if not len(state_content) > 0:

--- a/CDC-Data-Reconciliation-Backend/server.py
+++ b/CDC-Data-Reconciliation-Backend/server.py
@@ -136,8 +136,6 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
         subprocess_args.append('-f')
     
     process = await asyncio.create_subprocess_exec(*subprocess_args)
-    
-    process = await asyncio.create_subprocess_exec(sys.executable, os.path.join(app.dir, "compare.py"), '-c', cdc_save_to, '-s', state_save_to, '-o', res_file)
     await process.wait()
     
 

--- a/CDC-Data-Reconciliation-Backend/server.py
+++ b/CDC-Data-Reconciliation-Backend/server.py
@@ -99,7 +99,7 @@ app.liteConn.commit()
 
 
 @app.post("/manual_report")
-async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFile = File(None)):
+async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFile = File(None), isCDCFilter: bool = Form(False)):
     folder_name = "temp"
     if not os.path.exists(os.path.join(app.dir, "temp")):
         os.makedirs(os.path.join(app.dir, "temp"))
@@ -124,6 +124,19 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
         f.write(state_content)
 
     res_file = os.path.join(app.dir, folder_name, id, "results.csv")
+    
+    # Creating argument list for running compare.py
+    subprocess_args = [sys.executable,
+                       os.path.join(app.dir, "compare.py"),
+                       '-c', cdc_save_to,
+                       '-s', state_save_to,
+                       '-o', res_file]
+    
+    if isCDCFilter:
+        subprocess_args.append('-f')
+    
+    process = await asyncio.create_subprocess_exec(*subprocess_args)
+    
     process = await asyncio.create_subprocess_exec(sys.executable, os.path.join(app.dir, "compare.py"), '-c', cdc_save_to, '-s', state_save_to, '-o', res_file)
     await process.wait()
     
@@ -175,7 +188,7 @@ async def manual_report(state_file: UploadFile = File(None), cdc_file:  UploadFi
 
 
 @app.post("/automatic_report")
-async def automatic_report(year: int, cdc_file:  UploadFile = File(None)):
+async def automatic_report(year: int, cdc_file:  UploadFile = File(None), isCDCFilter: bool = Form(False)):
     # Run query to retrieve data from NBS ODSE database
     (column_names, state_content) = run_query(year)
     if not len(state_content) > 0:
@@ -211,7 +224,17 @@ async def automatic_report(year: int, cdc_file:  UploadFile = File(None)):
 
     # Do comparison
     res_file = os.path.join(app.dir, folder_name, id, "results.csv")
-    process = await asyncio.create_subprocess_exec(sys.executable, os.path.join(app.dir, "compare.py"), '-c', cdc_save_to, '-s', state_save_to, '-o', res_file)
+    # Creating argument list for running compare.py
+    subprocess_args = [sys.executable,
+                       os.path.join(app.dir, "compare.py"),
+                       '-c', cdc_save_to,
+                       '-s', state_save_to,
+                       '-o', res_file]
+    
+    if isCDCFilter:
+        subprocess_args.append('-f')
+    
+    process = await asyncio.create_subprocess_exec(*subprocess_args)
     await process.wait()
 
 

--- a/CDC-Data-Reconciliation-Frontend/src/components/CreateReport.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/CreateReport.jsx
@@ -46,6 +46,7 @@ export default function CreateReport({ onDone }) {
       // Setting form data to year and cdcFile
       const formdata = new FormData()
       formdata.append("cdc_file", cdcFile)
+      formdata.append("isCDCFilter", isCDCFilter)
 
       // Run the automatic report fetching
       try {
@@ -74,6 +75,7 @@ export default function CreateReport({ onDone }) {
       const formdata = new FormData()
       formdata.append("state_file", stateFile)
       formdata.append("cdc_file", cdcFile)
+      formdata.append("isCDCFilter", isCDCFilter)
 
       try {
         const response = await fetch(config.API_URL + "/manual_report", {

--- a/CDC-Data-Reconciliation-Frontend/src/components/CreateReport.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/CreateReport.jsx
@@ -50,7 +50,7 @@ export default function CreateReport({ onDone }) {
 
       // Run the automatic report fetching
       try {
-        const response = await fetch(config.API_URL + `/automatic_report?year=${inputValue}`, {
+        const response = await fetch(config.API_URL + `/automatic_report?year=${inputValue}&isCDCFilter=${isCDCFilter}`, {
           method: "POST",
           body: formdata,
         })
@@ -78,7 +78,7 @@ export default function CreateReport({ onDone }) {
       formdata.append("isCDCFilter", isCDCFilter)
 
       try {
-        const response = await fetch(config.API_URL + "/manual_report", {
+        const response = await fetch(config.API_URL + `/manual_report?isCDCFilter=${isCDCFilter}`, {
           method: "POST",
           body: formdata,
         })


### PR DESCRIPTION
Pass cdc filter option to backend from frontend by adding isCDCFilter to formdata, and then accepting on the backend. Conditionally adding '-f' to compare arguments if isCDCFilter is true.