### PR TITLE
JID3314-123 Add headers for report tables

### DIFF
--- a/CDC-Data-Reconciliation-Frontend/src/components/Filter.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Filter.jsx
@@ -19,7 +19,10 @@ export default function Filter({ column }) {
       <DebouncedInput
         type='text'
         value={columnFilterValue ?? ""}
-        onChange={(value) => column.setFilterValue(String(value))}
+        onChange={(value) => {
+          if (columnFilterValue === value) return
+          column.setFilterValue(String(value))
+        }}
         placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
         className='border shadow rounded w-full px-2 font-normal'
         list={column.id + "list"}

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -423,7 +423,7 @@ export default function Report({ reportID }) {
               <table className='w-full text-center mb-4 shadow-md'>
                 <thead className='bg-slate-100'>
                 <tr>
-                  <th colSpan={5} className="text-2xl">Report Statistics</th>
+                  <th colSpan={5} className="text-2xl p-2">Report Statistics</th>
                 </tr>
                   <tr className='border-b-2 border-slate-900'>
                     <th className='px-4 py-2 font-semibold'>Total Cases</th>
@@ -477,7 +477,7 @@ export default function Report({ reportID }) {
                     <table className='table-auto'>
                       <thead>
                         <tr>
-                          <th colSpan={7} className="text-2xl">Disease Statistics</th>
+                          <th colSpan={7} className="text-2xl p-2">Disease Statistics</th>
                         </tr>
                         {statTable.getHeaderGroups().map((headerGroup) => (
                           <tr key={headerGroup.id} className='border-b border-slate-400'>
@@ -637,7 +637,7 @@ export default function Report({ reportID }) {
               <table className='table-auto'>
                 <thead>
                   <tr>
-                    <th colSpan={7} className="text-2xl">
+                    <th colSpan={7} className="text-2xl p-2">
                       {currentDisease && currentDiscType ? `${currentDisease} ${currentDiscType}` : 'Report Discrepancies'}
                     </th>
                   </tr>

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -36,6 +36,9 @@ export default function Report({ reportID }) {
   const [statColumnFilters, setStatColumnFilters] = useState([])
   const [statGlobalFilter, setStatGlobalFilter] = useState("")
 
+  const [currentDisease, setCurrentDisease] = useState("")
+  const [currentDiscType, setCurrentDiscType] = useState("")
+
   const discColumns = useMemo(() => [
     {
       header: "CaseID",
@@ -296,9 +299,14 @@ export default function Report({ reportID }) {
   }
 
   const handleStatClick = (col, row) => {
+    // clear the filters of the report discrepancies table
     setDiscColumnFilters(null)
+    // set the current disease for the header of the report discrepancies table
+    setCurrentDisease(row.EventName)
+    let discrepancyType = ""
     switch (col.id) {
       case "TotalDuplicates":
+        discrepancyType = "Duplicates"
         if (row.TotalDuplicates === 0) return
 
         setDiscColumnFilters([
@@ -311,7 +319,9 @@ export default function Report({ reportID }) {
             value: row.EventCode,
           },
         ])
+        break
       case "TotalMissingFromCDC":
+        discrepancyType = "Missing From CDC"
         if (row.TotalMissingFromCDC === 0) return
 
         setDiscColumnFilters([
@@ -327,6 +337,7 @@ export default function Report({ reportID }) {
         break
 
       case "TotalWrongAttributes":
+        discrepancyType = "Wrong Attributes"
         if (row.TotalWrongAttributes === 0) return
 
         setDiscColumnFilters([
@@ -341,6 +352,7 @@ export default function Report({ reportID }) {
         ])
         break
       case "TotalMissingFromState":
+        discrepancyType = "Missing From State"
         if (row.TotalMissingFromState === 0) return
 
         setDiscColumnFilters([
@@ -354,12 +366,17 @@ export default function Report({ reportID }) {
           },
         ])
         break
+      default:
+        discrepancyType = ""
     }
+    setCurrentDiscType(discrepancyType)
   }
 
   const clearDiscFilters = () => {
     setDiscColumnFilters([])
     setDiscGlobalFilter("")
+    setCurrentDisease("")
+    setCurrentDiscType("")
   }
 
   const clearStatFilters = () => {
@@ -390,6 +407,9 @@ export default function Report({ reportID }) {
 
               <table className='w-full text-center mb-4 shadow-md'>
                 <thead className='bg-slate-100'>
+                <tr>
+                  <th colSpan={5} className="text-2xl">Report Statistics</th>
+                </tr>
                   <tr className='border-b-2 border-slate-900'>
                     <th className='px-4 py-2 font-semibold'>Total Cases</th>
                     <th className='px-4 py-2 font-semibold'>Total Duplicates</th>
@@ -441,6 +461,9 @@ export default function Report({ reportID }) {
                   <div className='border border-slate-400 rounded-xl my-3'>
                     <table className='table-auto'>
                       <thead>
+                        <tr>
+                          <th colSpan={7} className="text-2xl">Disease Statistics</th>
+                        </tr>
                         {statTable.getHeaderGroups().map((headerGroup) => (
                           <tr key={headerGroup.id} className='border-b border-slate-400'>
                             {headerGroup.headers.map((header) => {
@@ -567,7 +590,8 @@ export default function Report({ reportID }) {
               )}
             </>
           )}
-
+          
+          {/* Report Discrepancies Table */}
           <div>
             <div className='w-full flex flex-row items-center justify-between'>
               <DebouncedInput
@@ -597,6 +621,11 @@ export default function Report({ reportID }) {
             <div className='border border-slate-400 rounded-xl my-3'>
               <table className='table-auto'>
                 <thead>
+                  <tr>
+                    <th colSpan={7} className="text-2xl">
+                      {currentDisease && currentDiscType ? `${currentDisease} ${currentDiscType}` : 'Report Discrepancies'}
+                    </th>
+                  </tr>
                   {discTable.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id} className='border-b border-slate-400'>
                       {headerGroup.headers.map((header) => {

--- a/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
+++ b/CDC-Data-Reconciliation-Frontend/src/components/Report.jsx
@@ -163,8 +163,22 @@ export default function Report({ reportID }) {
         pageSize: 5,
       },
     },
-    onColumnFiltersChange: setDiscColumnFilters,
-    onGlobalFilterChange: setDiscGlobalFilter,
+    onColumnFiltersChange: (columnFilters) => {
+      if (currentDiscType != "" && currentDisease != "") {
+        setCurrentDiscType("")
+        setCurrentDisease("")
+      }
+
+      setDiscColumnFilters(columnFilters)
+    },
+    onGlobalFilterChange: (filter) => {
+      if (currentDiscType != "" && currentDisease != "") {
+        setCurrentDiscType("")
+        setCurrentDisease("")
+      }
+
+      setDiscGlobalFilter(filter)
+    },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -300,7 +314,8 @@ export default function Report({ reportID }) {
 
   const handleStatClick = (col, row) => {
     // clear the filters of the report discrepancies table
-    setDiscColumnFilters(null)
+    discTable.setColumnFilters([])
+    discTable.setGlobalFilter("")
     // set the current disease for the header of the report discrepancies table
     setCurrentDisease(row.EventName)
     let discrepancyType = ""
@@ -309,7 +324,7 @@ export default function Report({ reportID }) {
         discrepancyType = "Duplicates"
         if (row.TotalDuplicates === 0) return
 
-        setDiscColumnFilters([
+        discTable.setColumnFilters([
           {
             id: "ReasonID",
             value: "1",
@@ -324,7 +339,7 @@ export default function Report({ reportID }) {
         discrepancyType = "Missing From CDC"
         if (row.TotalMissingFromCDC === 0) return
 
-        setDiscColumnFilters([
+        discTable.setColumnFilters([
           {
             id: "ReasonID",
             value: "2",
@@ -340,7 +355,7 @@ export default function Report({ reportID }) {
         discrepancyType = "Wrong Attributes"
         if (row.TotalWrongAttributes === 0) return
 
-        setDiscColumnFilters([
+        discTable.setColumnFilters([
           {
             id: "ReasonID",
             value: "3",
@@ -355,7 +370,7 @@ export default function Report({ reportID }) {
         discrepancyType = "Missing From State"
         if (row.TotalMissingFromState === 0) return
 
-        setDiscColumnFilters([
+        discTable.setColumnFilters([
           {
             id: "ReasonID",
             value: "4",
@@ -373,15 +388,15 @@ export default function Report({ reportID }) {
   }
 
   const clearDiscFilters = () => {
-    setDiscColumnFilters([])
-    setDiscGlobalFilter("")
+    discTable.setColumnFilters([])
+    discTable.setGlobalFilter("")
     setCurrentDisease("")
     setCurrentDiscType("")
   }
 
   const clearStatFilters = () => {
-    setStatColumnFilters([])
-    setStatGlobalFilter("")
+    statTable.setColumnFilters([])
+    statTable.setGlobalFilter("")
   }
 
   return (
@@ -436,7 +451,7 @@ export default function Report({ reportID }) {
                   <div className='w-full flex flex-row items-center justify-between'>
                     <DebouncedInput
                       value={statGlobalFilter ?? ""}
-                      onChange={(value) => setStatGlobalFilter(String(value))}
+                      onChange={(value) => statTable.setGlobalFilter(String(value))}
                       className='p-2 font-lg shadow border border-block'
                       placeholder='Search all columns...'
                     />
@@ -596,7 +611,7 @@ export default function Report({ reportID }) {
             <div className='w-full flex flex-row items-center justify-between'>
               <DebouncedInput
                 value={discGlobalFilter ?? ""}
-                onChange={(value) => setDiscGlobalFilter(String(value))}
+                onChange={(value) => discTable.setGlobalFilter(String(value))}
                 className='p-2 font-lg shadow border border-block'
                 placeholder='Search all columns...'
               />


### PR DESCRIPTION
I added a static header for the report statistics summary along with static headers for the disease statistics and report discrepancies tables. Coupled with that, I added a dynamic header functionality for the report discrepancy table so that when a stat is clicked, the header for the report discrepancies table updates as well.
<img width="908" alt="Screenshot 2024-03-12 at 3 29 51 PM" src="https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/80718213/03f0ff16-19a9-4447-8539-70527c678180">
<img width="903" alt="Screenshot 2024-03-12 at 3 30 04 PM" src="https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/80718213/8a64eb4d-830d-4a7d-a067-9fc0f1972337">
<img width="901" alt="Screenshot 2024-03-12 at 3 30 18 PM" src="https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/80718213/d0a8c12c-018b-491b-ba2e-076bfb8010e2">
<img width="911" alt="Screenshot 2024-03-12 at 3 30 37 PM" src="https://github.com/waffy1901/JID-3314-CDC-Data-Reconciliation/assets/80718213/bf7386e3-c810-4708-9a1c-548bc6476e46">
