### PR TITLE
Fix mimetypes

### DIFF
--- a/CDC-Data-Reconciliation-Backend/server.py
+++ b/CDC-Data-Reconciliation-Backend/server.py
@@ -12,6 +12,12 @@ import pyodbc
 import json
 import sqlite3
 import shutil
+import mimetypes
+
+# Fix mimetypes for .js and .css files
+mimetypes.init()
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("text/css", ".css")
 
 app = FastAPI()
 


### PR DESCRIPTION
This is for people who's windows registry is corrupted or faulty when it comes to mimetypes to use within python.